### PR TITLE
Swift 4 support

### DIFF
--- a/EasyDi.xcodeproj/project.pbxproj
+++ b/EasyDi.xcodeproj/project.pbxproj
@@ -7,8 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C317CA641F1C7C2A00FAD212 /* EasyDi.swift in Sources */ = {isa = PBXBuildFile; fileRef = C317CA631F1C7C2A00FAD212 /* EasyDi.swift */; };
-		C317CA671F1C7C3400FAD212 /* EasyDi.h in Headers */ = {isa = PBXBuildFile; fileRef = C317CA651F1C7C3400FAD212 /* EasyDi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BEE13521F9A27C800A02331 /* EasyDi.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEE13501F9A27C800A02331 /* EasyDi.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BEE13531F9A27C800A02331 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8BEE13511F9A27C800A02331 /* Info.plist */; };
+		8BEE13561F9A27EA00A02331 /* EasyDi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE13551F9A27EA00A02331 /* EasyDi.swift */; };
+		8BEE13571F9A27F200A02331 /* EasyDi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE13551F9A27EA00A02331 /* EasyDi.swift */; };
 		C3614B541F1C8B6800B1F4A1 /* Test_Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B451F1C8B5F00B1F4A1 /* Test_Context.swift */; };
 		C3614B551F1C8B6800B1F4A1 /* Test_CrossAssemblyInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B461F1C8B5F00B1F4A1 /* Test_CrossAssemblyInjections.swift */; };
 		C3614B561F1C8B6800B1F4A1 /* Test_Injections.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B471F1C8B5F00B1F4A1 /* Test_Injections.swift */; };
@@ -19,7 +21,6 @@
 		C3614B5D1F1C8BAE00B1F4A1 /* EasyDi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C36D9F501F1C0DC9009FD9AD /* EasyDi.framework */; };
 		C37DEA1C1F1E9AA000279AD3 /* EasyDi_macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C37DEA1A1F1E9AA000279AD3 /* EasyDi_macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C37DEA291F1E9AE500279AD3 /* EasyDi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C37DEA181F1E9AA000279AD3 /* EasyDi.framework */; };
-		C37DEA2F1F1E9B0500279AD3 /* EasyDi.swift in Sources */ = {isa = PBXBuildFile; fileRef = C317CA631F1C7C2A00FAD212 /* EasyDi.swift */; };
 		C37DEA301F1E9B2100279AD3 /* Test_Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B451F1C8B5F00B1F4A1 /* Test_Context.swift */; };
 		C37DEA311F1E9B2100279AD3 /* Test_CrossAssemblyInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B461F1C8B5F00B1F4A1 /* Test_CrossAssemblyInjections.swift */; };
 		C37DEA321F1E9B2100279AD3 /* Test_Injections.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B471F1C8B5F00B1F4A1 /* Test_Injections.swift */; };
@@ -49,9 +50,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		C317CA631F1C7C2A00FAD212 /* EasyDi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EasyDi.swift; path = Sources/EasyDi.swift; sourceTree = SOURCE_ROOT; };
-		C317CA651F1C7C3400FAD212 /* EasyDi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EasyDi.h; path = "EasyDi-SupportingFiles/EasyDi.h"; sourceTree = SOURCE_ROOT; };
-		C317CA661F1C7C3400FAD212 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "EasyDi-SupportingFiles/Info.plist"; sourceTree = SOURCE_ROOT; };
+		8BEE13501F9A27C800A02331 /* EasyDi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EasyDi.h; sourceTree = "<group>"; };
+		8BEE13511F9A27C800A02331 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8BEE13551F9A27EA00A02331 /* EasyDi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EasyDi.swift; sourceTree = "<group>"; };
 		C3614B3B1F1C8AE900B1F4A1 /* EasyDi-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "EasyDi-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3614B441F1C8B5F00B1F4A1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = SOURCE_ROOT; };
 		C3614B451F1C8B5F00B1F4A1 /* Test_Context.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Test_Context.swift; path = Tests/Test_Context.swift; sourceTree = SOURCE_ROOT; };
@@ -104,6 +105,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8BEE134F1F9A27C800A02331 /* EasyDi-SupportingFiles */ = {
+			isa = PBXGroup;
+			children = (
+				8BEE13501F9A27C800A02331 /* EasyDi.h */,
+				8BEE13511F9A27C800A02331 /* Info.plist */,
+			);
+			path = "EasyDi-SupportingFiles";
+			sourceTree = "<group>";
+		};
+		8BEE13541F9A27EA00A02331 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				8BEE13551F9A27EA00A02331 /* EasyDi.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		C3614B431F1C8B4600B1F4A1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,15 +135,15 @@
 				C3614B4A1F1C8B5F00B1F4A1 /* Test_Scope.swift */,
 				C3614B4B1F1C8B5F00B1F4A1 /* Test_StructsInjection.swift */,
 			);
-			name = Tests;
-			path = EasyDi;
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		C36D9F461F1C0DC9009FD9AD = {
 			isa = PBXGroup;
 			children = (
-				C36D9F521F1C0DC9009FD9AD /* EasyDi */,
+				8BEE13541F9A27EA00A02331 /* Sources */,
 				C3614B431F1C8B4600B1F4A1 /* Tests */,
+				8BEE134F1F9A27C800A02331 /* EasyDi-SupportingFiles */,
 				C37DEA191F1E9AA000279AD3 /* EasyDi-macOS */,
 				C37DEA251F1E9AE500279AD3 /* EasyDi_macOS-Tests */,
 				C36D9F511F1C0DC9009FD9AD /* Products */,
@@ -141,16 +159,6 @@
 				C37DEA241F1E9AE500279AD3 /* EasyDi_macOS-Tests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		C36D9F521F1C0DC9009FD9AD /* EasyDi */ = {
-			isa = PBXGroup;
-			children = (
-				C317CA651F1C7C3400FAD212 /* EasyDi.h */,
-				C317CA661F1C7C3400FAD212 /* Info.plist */,
-				C317CA631F1C7C2A00FAD212 /* EasyDi.swift */,
-			);
-			path = EasyDi;
 			sourceTree = "<group>";
 		};
 		C37DEA191F1E9AA000279AD3 /* EasyDi-macOS */ = {
@@ -177,7 +185,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C317CA671F1C7C3400FAD212 /* EasyDi.h in Headers */,
+				8BEE13521F9A27C800A02331 /* EasyDi.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,6 +332,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BEE13531F9A27C800A02331 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -363,7 +372,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C317CA641F1C7C2A00FAD212 /* EasyDi.swift in Sources */,
+				8BEE13561F9A27EA00A02331 /* EasyDi.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,7 +380,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C37DEA2F1F1E9B0500279AD3 /* EasyDi.swift in Sources */,
+				8BEE13571F9A27F200A02331 /* EasyDi.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -409,6 +418,7 @@
 		C3614B411F1C8AE900B1F4A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -427,6 +437,7 @@
 		C3614B421F1C8AE900B1F4A1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -569,7 +580,7 @@
 				PRODUCT_NAME = EasyDi;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -591,7 +602,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.andreyzarembo.easydi;
 				PRODUCT_NAME = EasyDi;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Example/Source/Service/ServiceAssembly.swift
+++ b/Example/Source/Service/ServiceAssembly.swift
@@ -15,18 +15,21 @@ class ServiceAssembly: Assembly {
             $0.apiClient = self.apiClient
             $0.baseURL = URL(string: "https://xkcd.com")
             $0.stripURLSuffix = "/info.0.json"
+            return $0
         }
     }
     
     var apiClient: IJSONAPIClient {
         return define(scope: .lazySingleton,init: JSONAPIClient()) {
             $0.session = self.session
+            return $0
         }
     }
     
     var imageService: ImageService {
         return define(scope: .lazySingleton, init: ImageService()) {
             $0.session = self.session
+            return $0
         }
     }
     

--- a/Example/Source/UI/FeedView/FeedViewAssembly.swift
+++ b/Example/Source/UI/FeedView/FeedViewAssembly.swift
@@ -16,6 +16,7 @@ class FeedViewAssembly: Assembly {
         defineInjection(into: feedViewController) {
             $0.xkcdService = self.serviceAssembly.xkcdService
             $0.imageService = self.serviceAssembly.imageService
+            return $0
         }
     }
 }

--- a/Sources/EasyDi.swift
+++ b/Sources/EasyDi.swift
@@ -7,16 +7,16 @@ import Foundation
 
 public typealias InjectableObject = Any
 
-/// This class is used to join assembly instanced into separated shared group. 
+/// This class is used to join assembly instances into separated shared group.
 ///
 /// All assemblies with one context shares object graph stack.
 ///
-/// Also easy assembly instance has it's own singleton storage, so singletons is created one per context.
+/// Also every assembly instance has it's own singleton storage, so singletons is created one per context.
 ///
-/// Each test should have it's own context to persist independance of tests.
-/// Substitutions also applyed to assembly instance in context and not shared between contexts.
+/// Each test should have it's own context to persist independance of other tests.
+/// Substitutions are also applied to an assembly instance in context and are not shared between contexts.
 ///
-/// Assemblies should obtain insances of each other via it's contexts to mantain graph consistency.
+/// Assemblies should obtain instances of other assemblies via their contexts to maintain graph consistency.
 ///
 ///  ```
 ///  lazy var anotherAssembly: AnotherAssemblyClass = self.context.assembly()
@@ -32,11 +32,10 @@ public final class DIContext {
     var objectGraphStorage: [String: InjectableObject] = [:]
     
     var objectGraphStackDepth:Int = 0
-    var zeroDepthInjectionClosures:[()->Void] = []
 
     public init() {}
 
-    /// This method creates assembly instance based on it's result.
+    /// This method creates assembly instance based on it's return type.
     ///
     /// - returns: Assembly instance
     ///
@@ -77,7 +76,7 @@ public final class DIContext {
     }
 }
 
-/// Helper protocol to get Assembly instanced based on it's class
+/// Helper protocol to get Assembly instantiated based on its class
 internal protocol AssemblyInternal {
     
     /// This method returns instance of assembly class
@@ -110,14 +109,14 @@ public enum Scope {
     
     /// [Singleton]: https://github.com/AndreyZarembo/EasyDi#singleton
     ///
-    /// Dependency is created one per assembly. And created only at resosultion, so why it's lazy
+    /// Dependency is created one per assembly. And created only at resosultion, that is why it's lazy
     ///
     /// [Singleton]  description contains short example with memory graph illustration
     case lazySingleton
 }
 
 
-/// This is assembly class. Is't used to describe dependencies and resolve it.
+/// This is assembly class. It is used to describe dependencies and resolve it.
 ///
 /// Syntax:
 /// ```
@@ -139,7 +138,7 @@ open class Assembly: AssemblyInternal {
 
     public internal(set) var context: DIContext!
 
-    /// This method creates assembly for specified context or default context if no paramters provided
+    /// This method creates assembly for specified context or default context if no parameters provided
     /// 
     /// - parameter context: DIContext object which assembly should belong to
     ///
@@ -163,17 +162,13 @@ open class Assembly: AssemblyInternal {
     ///
     /// Dictionary key is **key** parameter from **define** method
     var singletons:[String: InjectableObject] = [:]
-    /// Temporary definitions cache
-    ///
-    /// Dictionary key is **key** parameter from **define** method
-    var definitions:[String: DefinitionInternal] = [:]
     
     /// Array of applyed substitutions
     ///
     /// Dictionary key is **key** parameter from **define** method
     internal var substitutions:[String: UntypedPatchClosure] = [:]
 
-    /// This method forces assembly to return result of closure instead of assemblies dependency.
+    /// This method forces assembly to return result of closure instead of the assembly's dependency.
     ///
     /// It's usefull to stub objects and make A / B testing
     ///
@@ -265,7 +260,7 @@ open class Assembly: AssemblyInternal {
         definitionKey: String = #function,
         scope: Scope = .objectGraph,
         into initClosure: @autoclosure @escaping () -> ObjectType,
-        inject injectClosure: @escaping ObjectInjectClosure<ObjectType> = { _ in } ) {
+        inject injectClosure: ObjectInjectClosure<ObjectType>? = nil ) {
         
         let _: ObjectType = self.define(
             key: key,
@@ -315,7 +310,7 @@ open class Assembly: AssemblyInternal {
         definitionKey: String = #function,
         scope: Scope = .objectGraph,
         init initClosure: @autoclosure @escaping () -> ObjectType,
-        inject injectClosure: @escaping ObjectInjectClosure<ObjectType> = { _ in } ) -> ResultType {
+        inject injectClosure: ObjectInjectClosure<ObjectType>? = nil ) -> ResultType {
 
         return self.define(key: key, definitionKey: definitionKey, scope: scope) { (definition:Definition<ObjectType>) in
             definition.initClosure = initClosure
@@ -371,31 +366,24 @@ open class Assembly: AssemblyInternal {
             
             result = objectFromStack
 
-        } else if let definition = self.definitions[definitionKey], var object = definition.initObject() {
-            
-            result = object as! ObjectType
-            context.objectGraphStorage[key] = result
-            self.context.zeroDepthInjectionClosures.append {
-                definition.injectObject(object: &object)
-            }
-        // Creating and initializing object
         } else {
 
             // Create Definition object to store injections and dependencies information
             let definition = Definition<ObjectType>()
             definitionClosure?(definition)
-            self.definitions[definitionKey] = definition
-            
+
+            context.objectGraphStackDepth += 1
             guard var object = definition.initObject() else {
                 fatalError("Failed to initialize object")
             }
+            context.objectGraphStackDepth -= 1
             
             // Object is created. It's stores in the object graph with it's key
             context.objectGraphStorage[key] = object
             // Going deeper to 'stack'.
             // Injections of this object will resolve dependencies recurently using objects from graph
             context.objectGraphStackDepth += 1
-            definition.injectObject(object: &object)
+            object = definition.injectObject(object: object)
             context.objectGraphStackDepth -= 1
 
             result = object as! ObjectType
@@ -403,14 +391,7 @@ open class Assembly: AssemblyInternal {
         
         // When recursion is finished, remove all objects from objectGraph
         if context.objectGraphStackDepth == 0 {
-            while let closure = self.context.zeroDepthInjectionClosures.popLast() {
-                context.objectGraphStorage[key] = result
-                context.objectGraphStackDepth += 1
-                closure()
-                context.objectGraphStackDepth -= 1
-            }
             context.objectGraphStorage.removeAll()
-            definitions.removeAll()
         }
 
         // And save singletons
@@ -431,7 +412,7 @@ open class Assembly: AssemblyInternal {
 internal protocol DefinitionInternal {
 
     func initObject() -> InjectableObject?
-    func injectObject(object: inout InjectableObject) -> Void
+    func injectObject(object: InjectableObject) -> InjectableObject
 }
 
 /// Definition object is used to store initialization and injection closures
@@ -441,24 +422,26 @@ public final class Definition<ObjectType: InjectableObject>: DefinitionInternal 
     public var injectClosure: ObjectInjectClosure<ObjectType>?
 
     func initObject() -> InjectableObject? {
-        
+
         return self.initClosure?()
     }
-    
-    func injectObject(object: inout InjectableObject) -> Void {
-        
-        guard var injectableObject = object as? ObjectType else {
-            
-            return
+
+    func injectObject(object: InjectableObject) -> InjectableObject {
+
+        guard let injectableObject = object as? ObjectType else {
+            fatalError()
         }
-        
-        self.injectClosure?(&injectableObject)
-        object = injectableObject
+
+        guard let actualInjectClosure = self.injectClosure else {
+            return object
+        }
+
+        return actualInjectClosure(injectableObject)
     }
 }
 
 public typealias ObjectInitClosure<ObjectType: InjectableObject> = () -> ObjectType
-public typealias ObjectInjectClosure<ObjectType: InjectableObject> = (_ object: inout ObjectType) -> Void
+public typealias ObjectInjectClosure<ObjectType: InjectableObject> = (_ object: ObjectType) -> ObjectType
 public typealias DefinitionClosure<ObjectType: InjectableObject> = (_ definition: Definition<ObjectType>) -> Void
 public typealias SubstitutionClosure<ObjectType: InjectableObject> = () -> ObjectType
 internal typealias UntypedPatchClosure = () -> InjectableObject

--- a/Tests/Test_CrossAssemblyInjections.swift
+++ b/Tests/Test_CrossAssemblyInjections.swift
@@ -37,6 +37,7 @@ class Test_CrossAssemblyInjections: XCTestCase {
                     self.testChildObjectAssembly.testChildObjectPrototype,
                     self.testChildObjectAssembly.testChildObjectPrototype
                 ]
+                return $0
             }
         }
     }
@@ -50,12 +51,14 @@ class Test_CrossAssemblyInjections: XCTestCase {
         var testChildObject: TestChildObject {
             return define(init: TestChildObject()) {
                 $0.parentObject = self.testObjectAssembly.testObject
+                return $0
             }
         }
         
         var testChildObjectPrototype: TestChildObject {
             return define(scope: .prototype, init: TestChildObject()) {
                 $0.parentObject = self.testObjectAssembly.testObject
+                return $0
             }
         }
     }

--- a/Tests/Test_CrossAssemblyInjections_SingletonCycle.swift
+++ b/Tests/Test_CrossAssemblyInjections_SingletonCycle.swift
@@ -36,6 +36,7 @@ class Test_CrossAssemblyInjections_SingletonCycle: XCTestCase {
                     self.testChildObjectAssembly.testChildObjectPrototype,
                     self.testChildObjectAssembly.testChildObjectPrototype
                 ]
+                return $0
             }
         }
     }
@@ -49,12 +50,14 @@ class Test_CrossAssemblyInjections_SingletonCycle: XCTestCase {
         var testChildObject: TestChildObject {
             return define(init: TestChildObject()) {
                 $0.parentObject = self.testObjectAssembly.testObject
+                return $0
             }
         }
         
         var testChildObjectPrototype: TestChildObject {
             return define(scope: .prototype, init: TestChildObject()) {
                 $0.parentObject = self.testObjectAssembly.testObject
+                return $0
             }
         }
     }

--- a/Tests/Test_Injections.swift
+++ b/Tests/Test_Injections.swift
@@ -29,6 +29,7 @@ class Test_Injection: XCTestCase {
                     $0.intParameter = 10
                     $0.stringParamter = "TestString"
                     $0.arrayParameter = ["a","b","c"]
+                    return $0
                 }
             }
         }
@@ -48,6 +49,7 @@ class Test_Injection: XCTestCase {
                     $0.intParameter = 10
                     $0.stringParamter = "TestString"
                     $0.arrayParameter = ["a","b","c"]
+                    return $0
                 }
             }
         }
@@ -70,6 +72,7 @@ class Test_Injection: XCTestCase {
                     $0.stringParamter = "TestString"
                     $0.arrayParameter = ["a","b","c"]
                     $0.selfParameter = self.testObject
+                    return $0
                 }
             }
             

--- a/Tests/Test_Patches.swift
+++ b/Tests/Test_Patches.swift
@@ -37,6 +37,7 @@ class Test_Substitutions: XCTestCase {
             return define(init: TestObject()) {
                 $0.intParameter = 10
                 $0.testChild = self.childTestObject
+                return $0
             }
         }
         
@@ -47,6 +48,7 @@ class Test_Substitutions: XCTestCase {
         var childTestObject: ChildTestSubstitutionObject {
             return define(init: ChildTestSubstitutionObject()) {
                 $0.parent = self.testObject
+                return $0
             }
         }
     }
@@ -79,6 +81,7 @@ class Test_Substitutions: XCTestCase {
             return testAssembly.define(init: TestObject2()) { testObj in
                 testObj.intParameter = testAssembly.testInteger
                 testObj.testChild = testAssembly.childTestObject
+                return testObj
             } as ITestSubstitutionObject
         }
         

--- a/Tests/Test_ProtocolBasedInjection.swift
+++ b/Tests/Test_ProtocolBasedInjection.swift
@@ -26,6 +26,7 @@ class Test_ProtocolInjection: XCTestCase {
         var testObject: TestProtocol {
             return define(init: TestObject()) {
                 $0.intParameter = 10
+                return $0
             }
         }
     }

--- a/Tests/Test_Scope.swift
+++ b/Tests/Test_Scope.swift
@@ -31,6 +31,7 @@ class Test_Scope: XCTestCase {
             var singleton: TestSingletonObject {
                 return define(scope: .lazySingleton, init: TestSingletonObject()) {
                     $0.injected = true
+                    return $0
                 }
             }
         }
@@ -70,12 +71,14 @@ class Test_Scope: XCTestCase {
             var parentObject: ParentObject {
                 return define(init: ParentObject()) {
                     $0.child = self.childObject
+                    return $0
                 }
             }
             
             var childObject: ChildObject {
                 return define(init: ChildObject()) {
                     $0.parent = self.parentObject
+                    return $0
                 }
             }
         }
@@ -114,12 +117,14 @@ class Test_Scope: XCTestCase {
             var prototypeObject: PrototypeObject {
                 return define(scope: .prototype, init: PrototypeObject()) {
                     $0.child = self.childObject
+                    return $0
                 }
             }
             
             var childObject: SupportChildObject {
                 return define(init: SupportChildObject()) {
                     $0.parent = self.prototypeObject
+                    return $0
                 }
             }
         }

--- a/Tests/Test_StructsInjection.swift
+++ b/Tests/Test_StructsInjection.swift
@@ -31,8 +31,10 @@ class Test_StructsInjection: XCTestCase {
             
             var testObject: TestStructsInjectionProtocol {
                 return define(init: TestStruct()) {
-                    $0.intValue = 10
-                    $0.stringValue = "TestString"
+                    var testStruct = $0
+                    testStruct.intValue = 10
+                    testStruct.stringValue = "TestString"
+                    return testStruct
                 }
             }
         }
@@ -60,13 +62,17 @@ class Test_StructsInjection: XCTestCase {
             
             var structA: TestStructProtocol {
                 return define(init: TestStructA()) {
-                    $0.anotherStruct = self.structB
+                    var testStruct = $0
+                    testStruct.anotherStruct = self.structB
+                    return testStruct
                 }
             }
             
             var structB: TestStructProtocol {
                 return define(init: TestStructB()) {
-                    $0.anotherStruct = self.structA
+                    var testStruct = $0
+                    testStruct.anotherStruct = self.structA
+                    return testStruct
                 }
             }
         }


### PR DESCRIPTION
Once I moved to Swift 4 I started receive crashes with bugs as [this issue](https://github.com/AndreyZarembo/EasyDi/issues/14)

I did some research and found [this document](https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md). In short it describes implemented in Swift 4 proposal to guarantee safer memory access in Swift 4 which I believe influenced logic of 'inout' attribute and escaping closures widely used in Assembly class. At the end of the doc author wrote that for the safer swift they are ready to sacrifice ABI compatibility. 
To bring our DI library to live we had to change 'define' method signature. 

I also let myself to correct some comments in EasyDi.swift file
