### PR TITLE
Drop Swift 3.0 support

### DIFF
--- a/EasyDi.xcodeproj/project.pbxproj
+++ b/EasyDi.xcodeproj/project.pbxproj
@@ -434,7 +434,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.andreyzarembo.easydi.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -453,7 +453,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.andreyzarembo.easydi.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -584,7 +584,7 @@
 				PRODUCT_NAME = EasyDi;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -606,7 +606,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.andreyzarembo.easydi;
 				PRODUCT_NAME = EasyDi;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -634,7 +634,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -661,7 +661,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -682,7 +682,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -703,7 +703,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Example/iOS Example.xcodeproj/project.pbxproj
+++ b/Example/iOS Example.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		C3614B0F1F1C7F1D00B1F4A1 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = C3614AF01F1C7F1D00B1F4A1 /* LaunchScreen.xib */; };
 		C3614B101F1C7F1D00B1F4A1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C3614AF21F1C7F1D00B1F4A1 /* Main.storyboard */; };
 		C3614B111F1C7F1D00B1F4A1 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C3614AF41F1C7F1D00B1F4A1 /* Images.xcassets */; };
-		C3614B121F1C7F1D00B1F4A1 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C3614AF51F1C7F1D00B1F4A1 /* Info.plist */; };
 		C3614B131F1C7F1D00B1F4A1 /* StripViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614AF91F1C7F1D00B1F4A1 /* StripViewController.swift */; };
 		C3614B141F1C7F1D00B1F4A1 /* XKCDStripCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614AFC1F1C7F1D00B1F4A1 /* XKCDStripCell.swift */; };
 		C3614B151F1C7F1D00B1F4A1 /* XKCDInfiniteScrollFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614AFD1F1C7F1D00B1F4A1 /* XKCDInfiniteScrollFooterView.swift */; };
@@ -27,7 +26,6 @@
 		C3614B1E1F1C7F1D00B1F4A1 /* XKCDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B081F1C7F1D00B1F4A1 /* XKCDService.swift */; };
 		C3614B1F1F1C7F1D00B1F4A1 /* IURLService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B091F1C7F1D00B1F4A1 /* IURLService.swift */; };
 		C3614B201F1C7F1D00B1F4A1 /* URLSession+IURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B0A1F1C7F1D00B1F4A1 /* URLSession+IURLSession.swift */; };
-		C3614B231F1C7F1D00B1F4A1 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C3614B0E1F1C7F1D00B1F4A1 /* Info.plist */; };
 		C3614B321F1C89A700B1F4A1 /* Test_JSONAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B0C1F1C7F1D00B1F4A1 /* Test_JSONAPIClient.swift */; };
 		C3614B331F1C89A700B1F4A1 /* Test_XKCDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3614B0D1F1C7F1D00B1F4A1 /* Test_XKCDService.swift */; };
 /* End PBXBuildFile section */
@@ -334,6 +332,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -390,11 +389,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C3614B231F1C7F1D00B1F4A1 /* Info.plist in Resources */,
 				C3614B0F1F1C7F1D00B1F4A1 /* LaunchScreen.xib in Resources */,
 				C3614B101F1C7F1D00B1F4A1 /* Main.storyboard in Resources */,
 				C3614B111F1C7F1D00B1F4A1 /* Images.xcassets in Resources */,
-				C3614B121F1C7F1D00B1F4A1 /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -610,7 +607,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.andreyzarembo.easydi.example.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example.app/iOS Example";
 			};
 			name = Debug;
@@ -624,7 +621,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.andreyzarembo.easydi.example.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example.app/iOS Example";
 			};
 			name = Release;


### PR DESCRIPTION
Newest Xcode (10.2) drops swift 3 support. This leads to failed attempts at Carthage installation