### PR TITLE
Package.swift update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,6 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
 // Copyright (c) 2017 Andrey Zarembo <andrey.zarembo@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -17,9 +20,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-// swift-tools-version:5.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,6 @@ import PackageDescription
 
 let package = Package(
 	name: "EasyDi",
-	platforms: [
-		.iOS(.v10)
-	],
 	products: [
 		.library(name: "EasyDi", targets: ["EasyDi"]),
 	],

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,9 @@ import PackageDescription
 
 let package = Package(
 	name: "EasyDi",
+	platforms: [
+		.iOS(.v10)
+	],
 	products: [
 		.library(name: "EasyDi", targets: ["EasyDi"]),
 	],

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-    name: "EasyDi",
-    dependencies : [],
-    exclude: ["Tests"]
+	name: "EasyDi",
+	products: [
+		.library(name: "EasyDi", targets: ["EasyDi"]),
+	],
+	targets: [
+		.target(name: "EasyDi", path: "Sources")
+	]
 )


### PR DESCRIPTION
Привет 👋 

Обновил Package.swift, чтобы можно было добавить EasyDi через SPM.

Потому что было вот так, когда я выставлял зависимость на конкретный комит:
<img width="613" alt="Screenshot 2020-02-28 at 20 28 03" src="https://user-images.githubusercontent.com/7022709/75581798-89041200-5a6a-11ea-8cea-1f5278181a48.png">

А при указании версии он отваливался с такой ошибкой:
<img width="299" alt="Screenshot 2020-02-28 at 20 44 20" src="https://user-images.githubusercontent.com/7022709/75582090-1a738400-5a6b-11ea-81ec-aba34ba3aa25.png">

Этот кусок `// swift-tools-version:5.0` должен идти первой строкой судя по всему. Иначе он его не считывает, если лежит после копирайта.