### PR TITLE
Upgrade Package.swift syntax for newest PackageDescription API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,11 @@ import PackageDescription
 
 let package = Package(
     name: "EasyDi",
+    products: [
+        .library(name: "EasyDi", targets: ["EasyDi"]),
+    ],
     dependencies : [],
-    exclude: ["Tests"]
+    targets: [
+        .target(name: "EasyDi", dependencies:[])
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.3
 // Copyright (c) 2017 Andrey Zarembo <andrey.zarembo@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,6 @@ let package = Package(
     ],
     dependencies : [],
     targets: [
-        .target(name: "EasyDi", dependencies:[])
+        .target(name: "EasyDi", dependencies:[], path: "Sources/")
     ]
 )


### PR DESCRIPTION
Upgraded `Package.swift` syntax accordingly to newest [PackageDescription API](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#product) and bumped `swift-tools-version` to 5.3